### PR TITLE
Fix fetchData reference in fee page

### DIFF
--- a/ucret.html
+++ b/ucret.html
@@ -1171,7 +1171,7 @@
     }
 
     // Initialize
-    document.addEventListener('DOMContentLoaded', fetchData);
+    document.addEventListener('DOMContentLoaded', fetchFeeData);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace nonexistent `fetchData` initialization with `fetchFeeData` in `ucret.html` to load tuition data properly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891bf1c7374832b9d44849fccbae93e