### PR TITLE
Fix fetchData reference in fee page

### DIFF
--- a/ucret.html
+++ b/ucret.html
@@ -693,11 +693,28 @@
           
           const rawData = await response.text();
           feeData = JSON.parse(rawData);
-          
+
+          if (Array.isArray(feeData)) {
+            const transformed = {};
+            feeData.forEach(item => {
+              const uni = item['üniversite'];
+              const program = item['program'];
+              if (!transformed[uni]) transformed[uni] = {};
+              transformed[uni][program] = {
+                price: item['ücret'],
+                description: item['açıklama'] || '',
+                level: item['öğrenim_düzeyi'] || '',
+                currency: 'TL',
+                period: 'yıllık'
+              };
+            });
+            feeData = transformed;
+          }
+
           if (!feeData || typeof feeData !== 'object' || Object.keys(feeData).length === 0) {
             throw new Error('JSON dosyası boş veya geçersiz format.');
           }
-          
+
           console.log(`✅ ${Object.keys(feeData).length} üniversite ücret verisi JSON dosyasından yüklendi.`);
           showSuccessMessage(`✅ <strong>Canlı Veri:</strong> ${Object.keys(feeData).length} üniversite ücret verisi başarıyla yüklendi`);
           
@@ -1171,7 +1188,7 @@
     }
 
     // Initialize
-    document.addEventListener('DOMContentLoaded', fetchData);
+    document.addEventListener('DOMContentLoaded', fetchFeeData);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace nonexistent `fetchData` initialization with `fetchFeeData` in `ucret.html` to load tuition data properly
- Transform fetched fee data arrays into per-university objects so the dropdown lists real university names

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891bf1c7374832b9d44849fccbae93e